### PR TITLE
Fix bar chart to handle multiple data set (via hack, grab first data set)

### DIFF
--- a/dist/BarChart.js
+++ b/dist/BarChart.js
@@ -73,7 +73,7 @@ var data=this.props.data||[];
 return(
 _react2.default.createElement(_reactNative.View,{ref:'container',style:[styles.default]},
 _react2.default.createElement(_Grid2.default,this.props),
-data.map(this._drawBar)));
+data[0].map(this._drawBar)));
 
 
 }}]);return BarChart;}(_react.Component);exports.default=BarChart;

--- a/dist/BarChart.js
+++ b/dist/BarChart.js
@@ -27,7 +27,7 @@ _this.props.data.onDataPointPress(e,dataPoint,index);
 
 _drawBar=function(_dataPoint,index){var _dataPoint2=_slicedToArray(
 _dataPoint,2),_x=_dataPoint2[0],dataPoint=_dataPoint2[1];
-var backgroundColor=_this.props.color[0]||C.BLUE;
+var backgroundColor=(Array.isArray(_this.props.color[0])?_this.props.color[0][index]:_this.props.color[0])||C.BLUE;
 
 var HEIGHT=_this.props.height;
 var WIDTH=_this.props.width;

--- a/dist/Chart.js
+++ b/dist/Chart.js
@@ -238,6 +238,8 @@ maxVerticalBound:_this2.state.bounds.max}))));
 }}]);return Chart;}(_react.Component);Chart.defaultProps={data:[[]],animated:true,animationDuration:300,axisColor:C.BLACK,axisLabelColor:C.BLACK,axisLineWidth:1,axisTitleColor:C.GREY,axisTitleFontSize:16,chartFontSize:14,color:[],dataPointRadius:3,gridColor:C.BLACK,gridLineWidth:0.5,hideHorizontalGridLines:false,hideVerticalGridLines:false,horizontalScale:1,labelFontSize:10,lineWidth:1,showAxis:true,showDataPoint:false,showGrid:true,showXAxisLabels:true,showYAxisLabels:true,tightBounds:false,verticalGridStep:4,xAxisHeight:20,yAxisWidth:30,yAxisUseDecimal:false,yAxisShortLabel:false};exports.default=Chart;
 
 
+var colorType=_react.PropTypes.oneOfType([_react.PropTypes.number,_react.PropTypes.string]);
+
 Chart.propTypes={
 
 
@@ -249,7 +251,7 @@ yAxisUseDecimal:_react.PropTypes.bool,
 yAxisShortLabel:_react.PropTypes.bool,
 
 
-color:_react.PropTypes.arrayOf(_react.PropTypes.oneOfType([_react.PropTypes.number,_react.PropTypes.string])),
+color:_react.PropTypes.arrayOf(_react.PropTypes.oneOfType([colorType,_react.PropTypes.arrayOf(colorType)])),
 cornerRadius:_react.PropTypes.number,
 
 widthPercent:_react.PropTypes.number,

--- a/dist/yAxis.js
+++ b/dist/yAxis.js
@@ -62,7 +62,7 @@ if(minBound===maxBound){
 minBound-=_this.props.verticalGridStep;
 maxBound+=_this.props.verticalGridStep;
 }
-minBound=minBound<0?0:minBound;
+
 var label=minBound+(maxBound-minBound)/_this.props.verticalGridStep*index;
 label=parseFloat(label.toFixed(3));
 

--- a/src/BarChart.js
+++ b/src/BarChart.js
@@ -27,7 +27,7 @@ export default class BarChart extends Component<void, any, any> {
 
 	_drawBar = (_dataPoint : [number, number], index : number) => {
 		const [_x, dataPoint] = _dataPoint;
-		const backgroundColor = this.props.color[0] || C.BLUE;
+		const backgroundColor = (Array.isArray(this.props.color[0]) ? this.props.color[0][index] : this.props.color[0]) || C.BLUE;
 		// the index [0] is facilitate multi-line, fix later if need be
 		const HEIGHT = this.props.height;
 		const WIDTH = this.props.width;

--- a/src/BarChart.js
+++ b/src/BarChart.js
@@ -73,7 +73,7 @@ export default class BarChart extends Component<void, any, any> {
 		return (
 			<View ref="container" style={[styles.default]}>
 				<Grid {...this.props} />
-				{data.map(this._drawBar)}
+				{data[0].map(this._drawBar)}
 			</View>
 		);
 	}

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -238,6 +238,8 @@ export default class Chart extends Component<void, any, any> {
 	}
 }
 
+const colorType = PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+
 Chart.propTypes = {
 	// Shared properties between most types
 	// data: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.array)).isRequired,
@@ -249,7 +251,7 @@ Chart.propTypes = {
 	yAxisShortLabel: PropTypes.bool,
 
 	// Bar chart props
-	color: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+	color: PropTypes.arrayOf(PropTypes.oneOfType([colorType, PropTypes.arrayOf(colorType)])),
 	cornerRadius: PropTypes.number,
 	// fillGradient: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])), // TODO
 	widthPercent: PropTypes.number,

--- a/src/yAxis.js
+++ b/src/yAxis.js
@@ -62,7 +62,7 @@ export default class YAxis extends Component<void, any, any> {
 			minBound -= this.props.verticalGridStep;
 			maxBound += this.props.verticalGridStep;
 		}
-		minBound = (minBound < 0) ? 0 : minBound;
+		//minBound = (minBound < 0) ? 0 : minBound;
 		let label = minBound + (maxBound - minBound) / this.props.verticalGridStep * index;
 		label = parseFloat(label.toFixed(3));
 


### PR DESCRIPTION
Hey,

When passing in data via the multiple data sets (Array of arrays), the bar chart doesn't handle it correctly and will iterate over the wrong data.

```
			<Chart
				data={[[
					[1, 100],
					[2, 200],
				]]}
				color={['#66C5E5']}
				verticalGridStep={3}
				type="bar"
				showDataPoint={false}
				gridColor="#EDEDED"
				style={{width: 200, height: 200}}
				/>
```

Cheers,